### PR TITLE
Blocking KokoroEngine

### DIFF
--- a/Core/KokoroEngine.cs
+++ b/Core/KokoroEngine.cs
@@ -9,25 +9,30 @@ using System.Collections.Concurrent;
 public class KokoroEngine : IDisposable {
     protected readonly KokoroModel model;
     protected readonly BlockingCollection<KokoroJob> queuedJobs = [];
-    private readonly CancellationTokenSource _cancellation = new();
+    private readonly CancellationTokenSource cancellation = new();
 
     /// <summary> Creates a new Kokoro Engine instance, loading the model into memory and initializing a background worker thread to continuously scan for newly queued jobs, dispatching them in order, when it's free. </summary>
     /// <remarks> If 'options' is specified, the model will be loaded with them. This is particularly useful when needing to run on non-CPU backends, as the default backend otherwise is the CPU with 8 threads. </remarks>
-    public KokoroEngine(string modelPath, SessionOptions options = null)
-    {
+    public KokoroEngine(string modelPath, SessionOptions options = null) {
         model = new KokoroModel(modelPath, options);
 
         new Thread(() =>
         {
-            foreach (var kokoroJob in queuedJobs.GetConsumingEnumerable(_cancellation.Token))
-                kokoroJob.Progress(model);
+            try {
+                while (queuedJobs.TryTake(out var kokoroJob, -1, cancellation.Token))
+                    while (!cancellation.IsCancellationRequested && !kokoroJob.isDone)
+                        kokoroJob.Progress(model);
+            }
+            catch (OperationCanceledException) {
+                // If cancellation was requested just swallow the cancellation exception and exit.
+            }
         }).Start();
     }
 
     /// <summary> Enqueues a job for the Kokoro TTS engine, scheduling it to be processed when the engine is free. </summary>
     /// <remarks> The job will be automatically dispatched when all prior jobs have been completed or canceled. Canceled jobs resolve and get skipped when their order arrives. </remarks>
     public KokoroJob EnqueueJob(KokoroJob job) {
-        ObjectDisposedException.ThrowIf(_cancellation.IsCancellationRequested, this);
+        ObjectDisposedException.ThrowIf(cancellation.IsCancellationRequested, this);
         queuedJobs.Add(job);
         return job;
     }
@@ -35,7 +40,7 @@ public class KokoroEngine : IDisposable {
     /// <summary> Immediately cancels any ongoing registered jobs and playbacks, frees memory taken by the model, and notifies the background worker thread to exit. </summary>
     /// <remarks> Note that this will not free up memory that the voices take (~25MB if ALL languages are loaded). </remarks>
     public virtual void Dispose() {
-        _cancellation.Cancel();
+        cancellation.Cancel();
         foreach (var job in queuedJobs) { job.Cancel(); }
         queuedJobs.Dispose();
         model.Dispose();

--- a/Core/KokoroEngine.cs
+++ b/Core/KokoroEngine.cs
@@ -9,7 +9,7 @@ using System.Collections.Concurrent;
 public class KokoroEngine : IDisposable {
     protected readonly KokoroModel model;
     protected readonly BlockingCollection<KokoroJob> queuedJobs = [];
-    private readonly CancellationTokenSource cancellation = new();
+    readonly CancellationTokenSource cancellation = new();
 
     /// <summary> Creates a new Kokoro Engine instance, loading the model into memory and initializing a background worker thread to continuously scan for newly queued jobs, dispatching them in order, when it's free. </summary>
     /// <remarks> If 'options' is specified, the model will be loaded with them. This is particularly useful when needing to run on non-CPU backends, as the default backend otherwise is the CPU with 8 threads. </remarks>

--- a/Core/KokoroEngine.cs
+++ b/Core/KokoroEngine.cs
@@ -8,42 +8,36 @@ using System.Collections.Concurrent;
 /// <remarks> Contains a background worker thread that dispatches queued jobs/actions linearly. </remarks>
 public class KokoroEngine : IDisposable {
     protected readonly KokoroModel model;
-    protected readonly ConcurrentQueue<KokoroJob> queuedJobs = [];
-
-    volatile bool hasExited;
+    protected readonly BlockingCollection<KokoroJob> queuedJobs = [];
+    private readonly CancellationTokenSource _cancellation = new();
 
     /// <summary> Creates a new Kokoro Engine instance, loading the model into memory and initializing a background worker thread to continuously scan for newly queued jobs, dispatching them in order, when it's free. </summary>
     /// <remarks> If 'options' is specified, the model will be loaded with them. This is particularly useful when needing to run on non-CPU backends, as the default backend otherwise is the CPU with 8 threads. </remarks>
-    public KokoroEngine(string modelPath, SessionOptions options = null) {
+    public KokoroEngine(string modelPath, SessionOptions options = null)
+    {
         model = new KokoroModel(modelPath, options);
 
-        new Thread(async () => {
-            while (!hasExited) {
-                await Task.Delay(10);
-                while (!hasExited && queuedJobs.TryDequeue(out var job)) {
-                    while (!hasExited && !job.isDone) {
-                        job.Progress(model);
-                        await Task.Delay(1);
-                    }
-                }
-            }
+        new Thread(() =>
+        {
+            foreach (var kokoroJob in queuedJobs.GetConsumingEnumerable(_cancellation.Token))
+                kokoroJob.Progress(model);
         }).Start();
     }
 
     /// <summary> Enqueues a job for the Kokoro TTS engine, scheduling it to be processed when the engine is free. </summary>
     /// <remarks> The job will be automatically dispatched when all prior jobs have been completed or canceled. Canceled jobs resolve and get skipped when their order arrives. </remarks>
     public KokoroJob EnqueueJob(KokoroJob job) {
-        ObjectDisposedException.ThrowIf(hasExited, this);
-        queuedJobs.Enqueue(job);
+        ObjectDisposedException.ThrowIf(_cancellation.IsCancellationRequested, this);
+        queuedJobs.Add(job);
         return job;
     }
 
     /// <summary> Immediately cancels any ongoing registered jobs and playbacks, frees memory taken by the model, and notifies the background worker thread to exit. </summary>
     /// <remarks> Note that this will not free up memory that the voices take (~25MB if ALL languages are loaded). </remarks>
     public virtual void Dispose() {
-        hasExited = true;
+        _cancellation.Cancel();
         foreach (var job in queuedJobs) { job.Cancel(); }
-        queuedJobs.Clear();
+        queuedJobs.Dispose();
         model.Dispose();
         GC.SuppressFinalize(this);
     }

--- a/Core/KokoroEngine.cs
+++ b/Core/KokoroEngine.cs
@@ -9,27 +9,16 @@ using System.Collections.Concurrent;
 public class KokoroEngine : IDisposable {
     protected readonly KokoroModel model;
     protected readonly BlockingCollection<KokoroJob> queuedJobs = [];
-    readonly CancellationTokenSource cancellation = new();
 
     /// <summary> Creates a new Kokoro Engine instance, loading the model into memory and initializing a background worker thread to continuously scan for newly queued jobs, dispatching them in order, when it's free. </summary>
     /// <remarks> If 'options' is specified, the model will be loaded with them. This is particularly useful when needing to run on non-CPU backends, as the default backend otherwise is the CPU with 8 threads. </remarks>
     public KokoroEngine(string modelPath, SessionOptions options = null) {
         model = new KokoroModel(modelPath, options);
 
-        new Thread(() =>
-        {
-            try {
-                while (queuedJobs.TryTake(out var kokoroJob, -1, cancellation.Token))
-                    while (!cancellation.IsCancellationRequested && !kokoroJob.isDone)
-                        kokoroJob.Progress(model);
+        new Thread(() => {
+            foreach (var kokoroJob in queuedJobs.GetConsumingEnumerable()) {
+                while (!kokoroJob.isDone) { kokoroJob.Progress(model); }
             }
-            catch (OperationCanceledException) {
-                // If cancellation was requested just swallow the cancellation exception and exit.
-            }
-
-            foreach (var kokoroJob in queuedJobs.GetConsumingEnumerable())
-                kokoroJob.Cancel();
-            queuedJobs.Dispose();
         }).Start();
     }
 
@@ -43,9 +32,8 @@ public class KokoroEngine : IDisposable {
     /// <summary> Immediately cancels any ongoing registered jobs and playbacks, frees memory taken by the model, and notifies the background worker thread to exit. </summary>
     /// <remarks> Note that this will not free up memory that the voices take (~25MB if ALL languages are loaded). </remarks>
     public virtual void Dispose() {
+        foreach (var job in queuedJobs) { job.Cancel(); }
         queuedJobs.CompleteAdding();
-        cancellation.Cancel();
         model.Dispose();
-        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Modified KokoroEngine to block, instead of poll with a very short timer.

This should be more responsive (no longer waiting 10ms between every job) and less wasteful (no longer spinning when waiting for work).

Since there's a cancellation token a future PR could wire it up into `kokoroJob.Progress(model);` to cancel that work partway, instead of it being an atomic unit.