### PR TITLE
Fixed current directory retrieval

### DIFF
--- a/HighLevel/KokoroVoiceManager.cs
+++ b/HighLevel/KokoroVoiceManager.cs
@@ -12,6 +12,9 @@ public static class KokoroVoiceManager {
     /// <summary> Gathers and loads all voices on the specified path. ("voices" is the default path the Nuget Package bundles the voices at). </summary>
     /// <remarks> This exists in case developers want to ship their project with custom paths or use custom voice loading logic. </remarks>
     public static void LoadVoicesFromPath(string voicesPath = "voices") {
+        if (voicesPath == "voices")
+            voicesPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, voicesPath);
+
         if (!Directory.Exists(voicesPath)) { throw new DirectoryNotFoundException(); }
         var voiceFilePaths = Directory.GetFiles(voicesPath);
 

--- a/Processing/Tokenizer.cs
+++ b/Processing/Tokenizer.cs
@@ -21,7 +21,7 @@ public static class Tokenizer {
 
     /// <summary> Path to the folder in which the espeak-ng binaries and data reside. Defaults to the folder created by the NuGet package. </summary>
     /// <remarks> Can be overriden with a custom path if a use-case requires so. </remarks>
-    public static string eSpeakNGPath { get; set; } = Path.Combine(Directory.GetCurrentDirectory(), "espeak");
+    public static string eSpeakNGPath { get; set; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "espeak");
 
     public static IReadOnlyDictionary<char, int> Vocab { get; }
     public static IReadOnlyDictionary<int, char> TokenToChar { get; }


### PR DESCRIPTION
This PR fixes errors finding certain paths when calling the KokoroSharp consuming applications from locations other than the location in which the application binaries are.

To maintain backwards compatibility, I opted for the `if (voicesPath == "voices")` check in `LoadVoicesFromPath`, so that the logic to create the 'current directory agnostic voices path' is only applied if the default value is used. 

This looks a bit silly so if you would like a different solution for this then we can think of something else. 

Maybe using `Path.IsPathRooted(voicesPath)` -- but this may not be backwards compatible.

I've been running it locally and have had no issues

This PR fixes issue #12
