### PR TITLE
Add support for phoneme literals in the tokenizer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,5 +14,14 @@ jobs:
             - uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: 8.0.x
+
+            - name: Download Release Assets
+              run: |
+                  mkdir -p release-assets
+                  curl -L -o release-assets/voices.zip https://github.com/Lyrcaxis/KokoroSharpBinaries/releases/download/v1.0.0/voices.zip
+                  curl -L -o release-assets/espeak.zip https://github.com/Lyrcaxis/KokoroSharpBinaries/releases/download/v1.0.0/espeak-ng-binaries-v1.52.zip
+                  unzip release-assets/voices.zip -d KokoroSharp
+                  unzip release-assets/espeak.zip -d KokoroSharp
+
             - name: Test
               run: dotnet test -c Release

--- a/KokoroSharp.Tests/TokenizerTests.cs
+++ b/KokoroSharp.Tests/TokenizerTests.cs
@@ -14,4 +14,11 @@ public class TokenizerTests {
     public async Task PreprocessText(string input, string expected) {
         await Assert.That(Tokenizer.PreprocessText(input)).IsEqualTo(expected);
     }
+
+    [Test]
+    [Arguments("[Misaki](/misˈɑki/) is a G2P engine designed for [Kokoro](/kˈOkəɹO/) models.", "misˈɑki ɪz ɐ dʒˈi tˈu pˈi ˈɛndʒɪn dɪzˈaɪnd fˌɔɹ kˈOkəɹO mˈɑːdəlz")]
+    [Arguments("Brits say [tomato](/təmɑːtoʊ/) instead of [tomato](/təmeɪtoʊ/).", "bɹˈɪts sˈeɪ təmɑːtoʊ ɪnstˈɛd ʌv təmeɪtoʊ")]
+    public async Task Phonemize(string input, string expected) {
+        await Assert.That(Tokenizer.Phonemize(input)).IsEqualTo(expected);
+    }
 }

--- a/KokoroSharp/Processing/Tokenizer.cs
+++ b/KokoroSharp/Processing/Tokenizer.cs
@@ -49,9 +49,16 @@ public static partial class Tokenizer {
 
 
     /// <summary> Converts the input text into the corresponding phonemes, with slight preprocessing and post-processing to preserve punctuation and other TTS essentials. </summary>
-    public static string Phonemize(string inputText, string langCode, bool preprocess = true) {
-        var preprocessedText = preprocess ? PreprocessText(inputText, langCode) : inputText;
-        var phonemeList = Phonemize_Internal(CollectSymbols(preprocessedText), out _, langCode).Split('\n');
+    public static string Phonemize(string inputText, string langCode = "en-us", bool preprocess = true) {
+        var strings = PhonemeLiteral().Split(inputText).Select(text => {
+            var m = PhonemeLiteral2().Match(text);
+            if (m.Success) { return m.Groups[1].Value; } // Extract the phoneme part from the literal pronunciation, e.g. [Kokoro](/kˈOkəɹO/) => "kˈOkəɹO"
+            if (preprocess) { text = PreprocessText(text, langCode); } // Preprocess the text if needed.
+            if (string.IsNullOrWhiteSpace(text)) { return string.Empty; } // Skip empty strings.
+            return Phonemize_Internal(CollectSymbols(text), out _, langCode); // Collect symbols to prepare for phonemization.
+        });
+        string preprocessedText = string.Join(' ', strings);
+        var phonemeList = preprocessedText.Split('\n');
         return PostProcessPhonemes(preprocessedText, phonemeList, langCode);
     }
 
@@ -195,19 +202,21 @@ public static partial class Tokenizer {
     [GeneratedRegex(@"\b(https?://)?(www\.)?[a-zA-Z0-9]+\b|\b[a-zA-Z0-9]+\.(com|net|org|io|edu|gov|mil|info|biz|co|us|uk|ca|de|fr|jp|au|cn|ru|gr)\b")]
                                                                      private static partial Regex WebUrl();
     [GeneratedRegex(@"^```[A-Za-z]{0,10}\n([\s\S]*?)\n```(?:\n|$)", RegexOptions.Multiline)]
-                                                                     private static partial Regex CodeBlock();     // Markdown code blocks: ```csharp\ncode\n```
-    [GeneratedRegex(@"\[(.*?)\]\(.*?\)")]                            private static partial Regex HeaderLink();    // Markdown links: [Header](link)
-    [GeneratedRegex(@"\[.*?\[(.*?)\].*?\]\(.*?\)|\[(.*?)\]\(.*?\)")] private static partial Regex HeaderImgLink(); // Markdown image links: [Header[(img](link)]
-    [GeneratedRegex(@"(\d)(\.)(\d+)")]                               private static partial Regex DecimalPoint();  // Decimal point: 3.1415
-    [GeneratedRegex(@"(?<!`)`([^`]+)`(?!`)")]                        private static partial Regex TickQuote();     // Inline code: `code`
-    [GeneratedRegex(@"\b(\d+(?:\.\d+)?)(KB|MB|GB|TB)(\s)")]          private static partial Regex ByteNumber();    // Byte numbers: 1KB, 2.5MB, etc.
-    [GeneratedRegex(@"([$€£¥₹₽₩₺₫]) ?(\d+)(?:[\.,](\d+))?")]         private static partial Regex Money();         // Money amounts: $1, €2.50, etc.
-    [GeneratedRegex(@"(\d+)(?:[\.,](\d+))? ?([$€£¥₹₽₩₺₫])")]         private static partial Regex Money2();        // Money amounts: 1€, 2,50€, etc.
-    [GeneratedRegex(@"\bD[Rr]\.(?= [A-Z])")]                         private static partial Regex Doctor();        // Doctor: Dr. Smith
-    [GeneratedRegex(@"\b(Mr|MR)\.(?= [A-Z])")]                       private static partial Regex Mister();        // Mister: Mr. Smith
-    [GeneratedRegex(@"\b(Ms|MS)\.(?= [A-Z])")]                       private static partial Regex Miss();          // Miss: Ms. Smith
-    [GeneratedRegex(@"\x20{2,}")]                                    private static partial Regex WhiteSpace();    // Multiple spaces: "  "
-    [GeneratedRegex(@"(?<!\:)\b([1-9]|1[0-2]):([0-5]\d)\b(?!\:)")]   private static partial Regex Time();          // Time: 12:30, 9:45, etc.
+                                                                     private static partial Regex CodeBlock();       // Markdown code blocks: ```csharp\ncode\n```
+    [GeneratedRegex(@"\[(.*?)\]\(.*?\)")]                            private static partial Regex HeaderLink();      // Markdown links: [Header](link)
+    [GeneratedRegex(@"\[.*?\[(.*?)\].*?\]\(.*?\)|\[(.*?)\]\(.*?\)")] private static partial Regex HeaderImgLink();   // Markdown image links: [Header[(img](link)]
+    [GeneratedRegex(@"(\d)(\.)(\d+)")]                               private static partial Regex DecimalPoint();    // Decimal point: 3.1415
+    [GeneratedRegex(@"(?<!`)`([^`]+)`(?!`)")]                        private static partial Regex TickQuote();       // Inline code: `code`
+    [GeneratedRegex(@"\b(\d+(?:\.\d+)?)(KB|MB|GB|TB)(\s)")]          private static partial Regex ByteNumber();      // Byte numbers: 1KB, 2.5MB, etc.
+    [GeneratedRegex(@"([$€£¥₹₽₩₺₫]) ?(\d+)(?:[\.,](\d+))?")]         private static partial Regex Money();           // Money amounts: $1, €2.50, etc.
+    [GeneratedRegex(@"(\d+)(?:[\.,](\d+))? ?([$€£¥₹₽₩₺₫])")]         private static partial Regex Money2();          // Money amounts: 1€, 2,50€, etc.
+    [GeneratedRegex(@"\bD[Rr]\.(?= [A-Z])")]                         private static partial Regex Doctor();          // Doctor: Dr. Smith
+    [GeneratedRegex(@"\b(Mr|MR)\.(?= [A-Z])")]                       private static partial Regex Mister();          // Mister: Mr. Smith
+    [GeneratedRegex(@"\b(Ms|MS)\.(?= [A-Z])")]                       private static partial Regex Miss();            // Miss: Ms. Smith
+    [GeneratedRegex(@"\x20{2,}")]                                    private static partial Regex WhiteSpace();      // Multiple spaces: "  "
+    [GeneratedRegex(@"(?<!\:)\b([1-9]|1[0-2]):([0-5]\d)\b(?!\:)")]   private static partial Regex Time();            // Time: 12:30, 9:45, etc.
+    [GeneratedRegex(@"(\[[^\]]+\]\(/[^/]+/\))")]                     private static partial Regex PhonemeLiteral();  // Literal Pronunciation: [Kokoro](/kˈOkəɹO/). Captures the entire string
+    [GeneratedRegex(@"\[[^\]]+\]\(/([^/]+)/\)")]                     private static partial Regex PhonemeLiteral2(); // Literal Pronunciation: [Kokoro](/kˈOkəɹO/). Captures only the phoneme part e.g. kˈOkəɹO
 
     #endregion Regexes
 }


### PR DESCRIPTION
Fixes #35 

Tells the tokenizer to not use espeak on parts look like this: `[Kokoro](/kˈOkəɹO/)`.
It should translate everything before and after that using espeak, but insert this part as `kˈOkəɹO` just before tokenizing.

I'm using the format from [misaki](https://github.com/hexgrad/misaki) because it's easy to detect using regex, but I'm open to suggestion for a better pattern.