### PR TITLE
Add Benchmarks

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+        <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.22.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\KokoroSharp\KokoroSharp.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Benchmark/Inference.cs
+++ b/Benchmark/Inference.cs
@@ -1,0 +1,38 @@
+﻿using BenchmarkDotNet.Attributes;
+
+using KokoroSharp;
+using KokoroSharp.Core;
+
+using System;
+using System.Collections.Generic;
+
+namespace Benchmark;
+
+[InProcess]
+public class Inference {
+    const string text = "This is a performance benchmark of Kokoro.";
+    static readonly Dictionary<(KModel, bool UseCuda), KokoroModel> models = [];
+    static int[] tokens;
+    static KokoroVoice voice;
+
+    [GlobalSetup]
+    public void Setup() {
+        tokens = KokoroSharp.Processing.Tokenizer.Tokenize(text);
+        voice = KokoroVoiceManager.GetVoice("af_heart");
+        foreach (var model in Enum.GetValues<KModel>()) {
+            if (!KokoroTTS.IsDownloaded(model))
+                KokoroTTS.LoadModel(model).Dispose(); // downloads the model if not already present.
+            var options = new Microsoft.ML.OnnxRuntime.SessionOptions();
+            models[(model, false)] = new KokoroModel(KokoroTTS.ModelNamesMap[model], options);
+            var options2 = new Microsoft.ML.OnnxRuntime.SessionOptions();
+            options2.AppendExecutionProvider_CUDA(); // Use CUDA for GPU inference.
+            models[(model, true)] = new KokoroModel(KokoroTTS.ModelNamesMap[model], options2);
+        }
+    }
+
+    [ParamsAllValues]
+    public KModel Model { get; set; }
+
+    [Benchmark] public float[] CPU() => models[(Model, false)].Infer(tokens, voice!.Features);
+    [Benchmark] public float[] CUDA() => models[(Model, true)].Infer(tokens, voice!.Features);
+}

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/Benchmark/Tokenizer.cs
+++ b/Benchmark/Tokenizer.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Attributes;
+
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Benchmark;
+
+[SimpleJob]
+public class Tokenizer {
+    static readonly string text = File.ReadAllText(Path.Join(GetMyPath(), "../../README.md"));
+    static string GetMyPath([CallerFilePath] string filePath = "") => filePath;
+
+    [Benchmark] public string PreprocessText() => KokoroSharp.Processing.Tokenizer.PreprocessText(text);
+    [Benchmark] public string Phonemize() => KokoroSharp.Processing.Tokenizer.Phonemize(text, "en-us");
+    [Benchmark] public int[] Tokenize() => KokoroSharp.Processing.Tokenizer.Tokenize(text);
+}

--- a/KokoroSharp.sln
+++ b/KokoroSharp.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KokoroSharp", "KokoroSharp\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KokoroSharp.Tests", "KokoroSharp.Tests\KokoroSharp.Tests.csproj", "{B0AB7C0B-D1C1-447C-9EB5-5CC9CB9E8943}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{FE74270D-B73E-4F9B-9467-2C225FD95FA1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{B0AB7C0B-D1C1-447C-9EB5-5CC9CB9E8943}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0AB7C0B-D1C1-447C-9EB5-5CC9CB9E8943}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0AB7C0B-D1C1-447C-9EB5-5CC9CB9E8943}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE74270D-B73E-4F9B-9467-2C225FD95FA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE74270D-B73E-4F9B-9467-2C225FD95FA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE74270D-B73E-4F9B-9467-2C225FD95FA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE74270D-B73E-4F9B-9467-2C225FD95FA1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/KokoroSharp/HighLevel/KokoroLoader.cs
+++ b/KokoroSharp/HighLevel/KokoroLoader.cs
@@ -8,7 +8,7 @@ using static KokoroSharp.KModel;
 public enum KModel { float32, float16, int8 }
 
 public partial class KokoroTTS {
-    static IReadOnlyDictionary<KModel, string> ModelNamesMap { get; } = new Dictionary<KModel, string>() {
+    internal static IReadOnlyDictionary<KModel, string> ModelNamesMap { get; } = new Dictionary<KModel, string>() {
         { float32, "kokoro.onnx" },
         { float16, "kokoro-quant.onnx" },
         { int8,    "kokoro-quant-convinteger.onnx" },

--- a/KokoroSharp/KokoroSharp.csproj
+++ b/KokoroSharp/KokoroSharp.csproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="KokoroSharp.Tests" />
+        <InternalsVisibleTo Include="KokoroSharp.Tests;Benchmark" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add a simple benchmark project.
It tests the performance of the tokenizer, text pre-processing and inference.
You can run it by calling:
`dotnet run --project Benchmark -c Release`

Example output:
```
| Method         |         Mean |       Error |      StdDev |
|----------------|-------------:|------------:|------------:|
| PreprocessText |     202.9 μs |     1.13 μs |     1.05 μs |
| Phonemize      | 148,545.9 μs | 2,866.41 μs | 2,541.00 μs |
| Tokenize       | 147,700.7 μs | 2,047.23 μs | 1,814.82 μs |
```

```
| Method | Model   |       Mean |    Error |   StdDev |
|--------|---------|-----------:|---------:|---------:|
| CPU    | float32 |   462.5 ms |  9.19 ms | 16.33 ms |
| CUDA   | float32 |   134.8 ms |  3.20 ms |  9.43 ms |
| CPU    | float16 |   432.3 ms |  8.63 ms | 15.99 ms |
| CUDA   | float16 |   214.0 ms |  3.36 ms |  3.14 ms |
| CPU    | int8    | 1,887.4 ms | 37.52 ms | 86.21 ms |
| CUDA   | int8    | 2,106.5 ms | 41.13 ms | 57.66 ms |
```