### PR TITLE
Made RUNNING_ON_GPU.md point to CUDA 12.4

### DIFF
--- a/RUNNING_ON_GPU.md
+++ b/RUNNING_ON_GPU.md
@@ -66,15 +66,20 @@ It's also possible to receive this error if you have more packages than you shou
 
 Always reset your IDE/terminal after installing dependencies, to make sure the system path is in sync.
 
+
+
 ### Exact list of CUDA / CUDNN libraries nessesary for inference
-- cudnn_engines_runtime_compiled64_9.dll
-- cudnn_engines_precompiled64_9.dll
-- cudnn_heuristic64_9.dll
-- cudnn_graph64_9.dll
-- cublasLt64_12.dll
-- cudnn_adv64_9.dll
-- cudnn_ops64_9.dll
-- cublas64_12.dll
-- cudart64_12.dll
-- cufft64_11.dll
-- cudnn64_9.dll
+<details>
+  <summary>(Preview)</summary>
+  - cudnn_engines_runtime_compiled64_9.dll <br>
+  - cudnn_engines_precompiled64_9.dll <br>
+  - cudnn_heuristic64_9.dll <br>
+  - cudnn_graph64_9.dll <br>
+  - cublasLt64_12.dll <br>
+  - cudnn_adv64_9.dll <br>
+  - cudnn_ops64_9.dll <br>
+  - cublas64_12.dll <br>
+  - cudart64_12.dll <br>
+  - cufft64_11.dll <br>
+  - cudnn64_9.dll <br>
+</details>

--- a/RUNNING_ON_GPU.md
+++ b/RUNNING_ON_GPU.md
@@ -29,7 +29,7 @@ tts.SpeakFast("Hello from GPU!", KokoroVoiceManager.GetVoice("af_heart"));
 
 For NVIDIA GPUs with CUDA support:
 - Choose either [KokoroSharp.GPU.Windows](https://www.nuget.org/packages/KokoroSharp.GPU.Windows), [KokoroSharp.GPU.Linux](https://www.nuget.org/packages/KokoroSharp.GPU.Linux), or [KokoroSharp.GPU](https://www.nuget.org/packages/KokoroSharp.GPU).
-- Download & install [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit), and make sure it's in SYSTEM PATH.
+- Download & install [CUDA Toolkit (v12.x)](https://developer.nvidia.com/cuda-12-4-0-download-archive), and make sure it's in SYSTEM PATH or put the libraries next to your compiled executable.
 - Download & install [cuDNN](https://developer.nvidia.com/cudnn), and make sure it's in SYSTEM PATH.
 - Restart your IDE/terminal after installation, then, run:
 ```cs
@@ -65,3 +65,16 @@ It's also possible to receive this error if you have more packages than you shou
 `DllNotFoundException` means you have no runtime AT ALL. For plug & play support (still fast), use the [KokoroSharp.CPU](https://www.nuget.org/packages/KokoroSharp.CPU) package.
 
 Always reset your IDE/terminal after installing dependencies, to make sure the system path is in sync.
+
+### Exact list of CUDA / CUDNN libraries nessesary for inference
+- cudnn_engines_runtime_compiled64_9.dll
+- cudnn_engines_precompiled64_9.dll
+- cudnn_heuristic64_9.dll
+- cudnn_graph64_9.dll
+- cublasLt64_12.dll
+- cudnn_adv64_9.dll
+- cudnn_ops64_9.dll
+- cublas64_12.dll
+- cudart64_12.dll
+- cufft64_11.dll
+- cudnn64_9.dll


### PR DESCRIPTION
Hello and thank you very much for great repo! I am eagerly awaiting every new release, while testing for my productions.

At the moment, GPU doc is misleading due to CUDA Toolkit (by link provided) updated to 13.0, which changed libraries names 
<img width="855" height="911" alt="image" src="https://github.com/user-attachments/assets/fbf38b47-feb6-4c50-bebd-db88ea96c66a" />
leading to errors
<img width="1107" height="388" alt="Screenshot 2025-08-21 132554" src="https://github.com/user-attachments/assets/78d9028c-65bf-4ae2-88be-5ea6458afcea" />
<img width="1117" height="133" alt="image" src="https://github.com/user-attachments/assets/7da75570-f894-4758-88bc-6403929930c9" />


Solution is to set link to archived version of CUDA Toolkit, like 12.4 (exact "12.4" is because it is also delivered with llama.cpp, for example). 

------

However, saying just for myself, even after clean installing CUDA Toolkit 12.9 **I still got errors** if not manually putting Nvidia libraries next to KokoroSharp console application .exe in runtime.
<img width="601" height="198" alt="image" src="https://github.com/user-attachments/assets/5ef5709b-d056-4933-9ea6-8522f8402b38" />

Maybe there is a bug related to detection of CUDA libraries? Or what am I doing wrong, if you may to share?
