### PR TITLE
Assign "ESPEAK_DATA_PATH" using indexer instead of .Add()

### DIFF
--- a/Processing/Tokenizer.cs
+++ b/Processing/Tokenizer.cs
@@ -80,7 +80,7 @@ public static partial class Tokenizer {
                 StandardOutputEncoding = Encoding.UTF8
             }
         };
-        process.StartInfo.EnvironmentVariables.Add("ESPEAK_DATA_PATH", @$"{eSpeakNGPath}/espeak-ng-data");
+        process.StartInfo.EnvironmentVariables["ESPEAK_DATA_PATH"] = @$"{eSpeakNGPath}/espeak-ng-data";
         process.Start();
         Task.Run(async () => {
             await process.StandardInput.WriteLineAsync(text);


### PR DESCRIPTION
Proposed fix for https://github.com/Lyrcaxis/KokoroSharp/issues/58
`StartInfo.EnvironmentVariables.Add()` can throw if the environment variable already exists. The proposed fix uses the indexer to clobber whatever might be in place and assign the value anyway.
Another solution would be to check if the variable already exists using `.ContainsKey()` then `.Remove()` it before calling `.Add()`